### PR TITLE
fix for random error being thrown

### DIFF
--- a/GamingStreamsTVApp/TwitchApi.swift
+++ b/GamingStreamsTVApp/TwitchApi.swift
@@ -47,6 +47,7 @@ class TwitchApi {
                                             return
                                         }
                                 }
+                                return
                             }
                         }
                     }


### PR DESCRIPTION
There was no return after the second request was kicked off in TwitchApi.getStreamsForChannel. Due to this, the completion handler was always getting called twice. The first time would always include an error, and the second time would be the correct completion after the second request returned.
